### PR TITLE
Support actual Flask-API extensions

### DIFF
--- a/generators/app/templates/app_init.py
+++ b/generators/app/templates/app_init.py
@@ -1,7 +1,7 @@
 from flask import Flask
-from flask.ext.marshmallow import Marshmallow
+from flask_marshmallow import Marshmallow
 <% if (databaseMapper === 'sqlalchemy') { -%>
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 <% } -%>
 
 from config import config


### PR DESCRIPTION
Add support to flask_marshmallow and flask_sqlalchemy [since flask.ext.sqlalchemy and flask.ext.marshmallow are now deprecated]